### PR TITLE
Smaller static

### DIFF
--- a/src/main/java/com/migcomponents/migbase64/Base64.java
+++ b/src/main/java/com/migcomponents/migbase64/Base64.java
@@ -2,6 +2,8 @@ package com.migcomponents.migbase64;
 
 import java.util.Arrays;
 
+import static com.migcomponents.migbase64.Dictionary.CA;
+
 /** A very fast and memory efficient class to encode and decode to and from BASE64 in full accordance
  * with RFC 2045.<br><br>
  * On Windows XP sp1 with 1.4.2_04 and later ;), this encoder and decoder is about 10 times faster
@@ -72,11 +74,10 @@ import java.util.Arrays;
 
 public class Base64
 {
-	private static final char[] CA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".toCharArray();
-	private static final int[] IA = new int[256];
+	private static final byte[] IA = new byte[256];
 	static {
-		Arrays.fill(IA, -1);
-		for (int i = 0, iS = CA.length; i < iS; i++)
+		Arrays.fill(IA, (byte) -1);
+		for (byte i = 0, iS = (byte) CA.length; i < iS; i++)
 			IA[CA[i]] = i;
 		IA['='] = 0;
 	}
@@ -110,10 +111,10 @@ public class Base64
 			int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
 
 			// Encode the int into four chars
-			dArr[d++] = CA[(i >>> 18) & 0x3f];
-			dArr[d++] = CA[(i >>> 12) & 0x3f];
-			dArr[d++] = CA[(i >>> 6) & 0x3f];
-			dArr[d++] = CA[i & 0x3f];
+			dArr[d++] = (char) CA[(i >>> 18) & 0x3f];
+			dArr[d++] = (char) CA[(i >>> 12) & 0x3f];
+			dArr[d++] = (char) CA[(i >>> 6) & 0x3f];
+			dArr[d++] = (char) CA[i & 0x3f];
 
 			// Add optional line separator
 			if (lineSep && ++cc == 19 && d < dLen - 2) {
@@ -130,9 +131,9 @@ public class Base64
 			int i = ((sArr[eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sLen - 1] & 0xff) << 2) : 0);
 
 			// Set last four chars
-			dArr[dLen - 4] = CA[i >> 12];
-			dArr[dLen - 3] = CA[(i >>> 6) & 0x3f];
-			dArr[dLen - 2] = left == 2 ? CA[i & 0x3f] : '=';
+			dArr[dLen - 4] = (char) CA[i >> 12];
+			dArr[dLen - 3] = (char) CA[(i >>> 6) & 0x3f];
+			dArr[dLen - 2] = (char) (left == 2 ? CA[i & 0x3f] : '=');
 			dArr[dLen - 1] = '=';
 		}
 		return dArr;

--- a/src/main/java/com/migcomponents/migbase64/Base64.java
+++ b/src/main/java/com/migcomponents/migbase64/Base64.java
@@ -300,10 +300,10 @@ public class Base64
 			int i = (sArr[s++] & 0xff) << 16 | (sArr[s++] & 0xff) << 8 | (sArr[s++] & 0xff);
 
 			// Encode the int into four chars
-			dArr[d++] = (byte) CA[(i >>> 18) & 0x3f];
-			dArr[d++] = (byte) CA[(i >>> 12) & 0x3f];
-			dArr[d++] = (byte) CA[(i >>> 6) & 0x3f];
-			dArr[d++] = (byte) CA[i & 0x3f];
+			dArr[d++] = CA[(i >>> 18) & 0x3f];
+			dArr[d++] = CA[(i >>> 12) & 0x3f];
+			dArr[d++] = CA[(i >>> 6) & 0x3f];
+			dArr[d++] = CA[i & 0x3f];
 
 			// Add optional line separator
 			if (lineSep && ++cc == 19 && d < dLen - 2) {
@@ -320,9 +320,9 @@ public class Base64
 			int i = ((sArr[sOff + eLen] & 0xff) << 10) | (left == 2 ? ((sArr[sOff + sLen - 1] & 0xff) << 2) : 0);
 
 			// Set last four chars
-			dArr[dLen - 4] = (byte) CA[i >> 12];
-			dArr[dLen - 3] = (byte) CA[(i >>> 6) & 0x3f];
-			dArr[dLen - 2] = left == 2 ? (byte) CA[i & 0x3f] : (byte) '=';
+			dArr[dLen - 4] = CA[i >> 12];
+			dArr[dLen - 3] = CA[(i >>> 6) & 0x3f];
+			dArr[dLen - 2] = left == 2 ? CA[i & 0x3f] : (byte) '=';
 			dArr[dLen - 1] = '=';
 		}
 		return dArr;

--- a/src/main/java/com/migcomponents/migbase64/Base64IO.java
+++ b/src/main/java/com/migcomponents/migbase64/Base64IO.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import com.migcomponents.migbase64.Base64;
+import static com.migcomponents.migbase64.Dictionary.CA;
 
 /**
  * Base64 for InputStream<br/> Licence = BSD
@@ -15,9 +15,6 @@ import com.migcomponents.migbase64.Base64;
  */
 public class Base64IO
 {
-
-    private static final byte[] CA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-            .getBytes();
 
     private static final int _8_BIT = 0xff;
 

--- a/src/main/java/com/migcomponents/migbase64/Dictionary.java
+++ b/src/main/java/com/migcomponents/migbase64/Dictionary.java
@@ -1,0 +1,5 @@
+package com.migcomponents.migbase64;
+
+/*package*/ interface Dictionary {
+    byte[] CA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".getBytes();
+}


### PR DESCRIPTION
Consuming less memory:
— replaced `char[64] Base64.CA` and `byte[64] Base64IO.CA` with a single shared `byte[64]` (-128 bytes)
— replaced `int[256] Base64.IA ` with `byte[256]` (-768 bytes);
— removed some int-to-byte narrowing casts, added byte-to-char expanding ones.
Speed test is running a bit faster on my machine — 12 seconds instead of 13.